### PR TITLE
Chat skeleton

### DIFF
--- a/MVP/MVP.xcodeproj/project.pbxproj
+++ b/MVP/MVP.xcodeproj/project.pbxproj
@@ -15,8 +15,13 @@
 		6D4A8A6B2458D64300F69923 /* Profile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6D4A8A692458D64300F69923 /* Profile.storyboard */; };
 		6D877E392459F4EE004C860D /* PhotoSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D877E382459F4EE004C860D /* PhotoSelectorViewController.swift */; };
 		6D9A0E21246094AB00245184 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9A0E20246094AB00245184 /* MapViewController.swift */; };
+		AC23ABC7245A82F9002D7764 /* Chat.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AC23ABC6245A82F9002D7764 /* Chat.storyboard */; };
+		AC23ABCB245A8C0C002D7764 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC23ABCA245A8C0C002D7764 /* Message.swift */; };
 		AC48CE522459E6B300C8D3A6 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC48CE502459E6B300C8D3A6 /* Post.swift */; };
 		AC48CE532459E6B300C8D3A6 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC48CE512459E6B300C8D3A6 /* User.swift */; };
+		AC9135BE245CCC68006562AA /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135BD245CCC68006562AA /* ChatViewController.swift */; };
+		AC9135C0245CCD5C006562AA /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135BF245CCD5C006562AA /* Chat.swift */; };
+		AC9135C2245E626F006562AA /* ChatListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135C1245E626F006562AA /* ChatListTableViewController.swift */; };
 		AC9A766C24574D4600AB1906 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC9A766B24574D4600AB1906 /* GoogleService-Info.plist */; };
 		ACEF808D245A149B009459FF /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEF808C245A149B009459FF /* Category.swift */; };
 		ACEF8091245A1A3A009459FF /* TestPostCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEF8090245A1A3A009459FF /* TestPostCategoryViewController.swift */; };
@@ -46,8 +51,13 @@
 		6D877E382459F4EE004C860D /* PhotoSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoSelectorViewController.swift; sourceTree = "<group>"; };
 		6D9A0E20246094AB00245184 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		8BCC7B77554AD8186970F80F /* Pods-MVP.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MVP.debug.xcconfig"; path = "Target Support Files/Pods-MVP/Pods-MVP.debug.xcconfig"; sourceTree = "<group>"; };
+		AC23ABC6245A82F9002D7764 /* Chat.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Chat.storyboard; sourceTree = "<group>"; };
+		AC23ABCA245A8C0C002D7764 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		AC48CE502459E6B300C8D3A6 /* Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		AC48CE512459E6B300C8D3A6 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		AC9135BD245CCC68006562AA /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
+		AC9135BF245CCD5C006562AA /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
+		AC9135C1245E626F006562AA /* ChatListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListTableViewController.swift; sourceTree = "<group>"; };
 		AC9A766B24574D4600AB1906 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		ACEF808C245A149B009459FF /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		ACEF8090245A1A3A009459FF /* TestPostCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPostCategoryViewController.swift; sourceTree = "<group>"; };
@@ -174,6 +184,8 @@
 				AC48CE502459E6B300C8D3A6 /* Post.swift */,
 				AC48CE512459E6B300C8D3A6 /* User.swift */,
 				ACEF808C245A149B009459FF /* Category.swift */,
+				AC23ABCA245A8C0C002D7764 /* Message.swift */,
+				AC9135BF245CCD5C006562AA /* Chat.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -199,6 +211,8 @@
 				6D9A0E20246094AB00245184 /* MapViewController.swift */,
 				D57620BA2460C0C000B5D417 /* ProfileViewController.swift */,
 				D576207B245A446300B5D417 /* Auth */,
+				AC9135BD245CCC68006562AA /* ChatViewController.swift */,
+				AC9135C1245E626F006562AA /* ChatListTableViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -219,6 +233,7 @@
 				6D4A8A602458D05500F69923 /* Home.storyboard */,
 				D5CF92CF24537B470059110B /* Main.storyboard */,
 				6D9A0E2224609B0B00245184 /* Custom Views */,
+				AC23ABC6245A82F9002D7764 /* Chat.storyboard */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -298,6 +313,7 @@
 				6D4A8A642458D07600F69923 /* AddPost.storyboard in Resources */,
 				6D4A8A6B2458D64300F69923 /* Profile.storyboard in Resources */,
 				D5CF92D124537B470059110B /* Main.storyboard in Resources */,
+				AC23ABC7245A82F9002D7764 /* Chat.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -354,6 +370,7 @@
 				6D4A8A662458D32700F69923 /* PostListTableViewController.swift in Sources */,
 				6D4A8A682458D34200F69923 /* PostDetailViewController.swift in Sources */,
 				D57620B92460B79200B5D417 /* PasswordResetViewController.swift in Sources */,
+				AC23ABCB245A8C0C002D7764 /* Message.swift in Sources */,
 				6D877E392459F4EE004C860D /* PhotoSelectorViewController.swift in Sources */,
 				D5CF92CA24537B470059110B /* AppDelegate.swift in Sources */,
 				6D9A0E21246094AB00245184 /* MapViewController.swift in Sources */,
@@ -362,9 +379,12 @@
 				D57620BB2460C0C000B5D417 /* ProfileViewController.swift in Sources */,
 				ACEF8091245A1A3A009459FF /* TestPostCategoryViewController.swift in Sources */,
 				D5762080245A44D700B5D417 /* Utilities.swift in Sources */,
+				AC9135C2245E626F006562AA /* ChatListTableViewController.swift in Sources */,
 				AC48CE522459E6B300C8D3A6 /* Post.swift in Sources */,
 				ACEF808D245A149B009459FF /* Category.swift in Sources */,
+				AC9135BE245CCC68006562AA /* ChatViewController.swift in Sources */,
 				D57620742458DE8F00B5D417 /* AddPostViewController.swift in Sources */,
+				AC9135C0245CCD5C006562AA /* Chat.swift in Sources */,
 				D5CF92CC24537B470059110B /* SceneDelegate.swift in Sources */,
 				D5762082245A44F500B5D417 /* SignUpViewController.swift in Sources */,
 				D5762088245A677F00B5D417 /* TabBarViewController.swift in Sources */,
@@ -530,7 +550,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9U46PJ4YSS;
+				DEVELOPMENT_TEAM = 6QY69PUF72;
 				INFOPLIST_FILE = MVP/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -548,8 +568,9 @@
 			baseConfigurationReference = F1873B08E8645ACC97E37AA2 /* Pods-MVP.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9U46PJ4YSS;
+				DEVELOPMENT_TEAM = 6QY69PUF72;
 				INFOPLIST_FILE = MVP/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -557,6 +578,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.coronacation.MVP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/MVP/MVP.xcodeproj/project.pbxproj
+++ b/MVP/MVP.xcodeproj/project.pbxproj
@@ -14,8 +14,12 @@
 		6D4A8A682458D34200F69923 /* PostDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4A8A672458D34200F69923 /* PostDetailViewController.swift */; };
 		6D4A8A6B2458D64300F69923 /* Profile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6D4A8A692458D64300F69923 /* Profile.storyboard */; };
 		6D877E392459F4EE004C860D /* PhotoSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D877E382459F4EE004C860D /* PhotoSelectorViewController.swift */; };
+		AC23ABC7245A82F9002D7764 /* Chat.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AC23ABC6245A82F9002D7764 /* Chat.storyboard */; };
+		AC23ABCB245A8C0C002D7764 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC23ABCA245A8C0C002D7764 /* Message.swift */; };
 		AC48CE522459E6B300C8D3A6 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC48CE502459E6B300C8D3A6 /* Post.swift */; };
 		AC48CE532459E6B300C8D3A6 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC48CE512459E6B300C8D3A6 /* User.swift */; };
+		AC9135BE245CCC68006562AA /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135BD245CCC68006562AA /* ChatViewController.swift */; };
+		AC9135C0245CCD5C006562AA /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135BF245CCD5C006562AA /* Chat.swift */; };
 		AC9A766C24574D4600AB1906 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC9A766B24574D4600AB1906 /* GoogleService-Info.plist */; };
 		ACEF808D245A149B009459FF /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEF808C245A149B009459FF /* Category.swift */; };
 		ACEF8091245A1A3A009459FF /* TestPostCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEF8090245A1A3A009459FF /* TestPostCategoryViewController.swift */; };
@@ -41,8 +45,12 @@
 		6D4A8A6A2458D64300F69923 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Profile.storyboard; sourceTree = "<group>"; };
 		6D877E382459F4EE004C860D /* PhotoSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoSelectorViewController.swift; sourceTree = "<group>"; };
 		8BCC7B77554AD8186970F80F /* Pods-MVP.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MVP.debug.xcconfig"; path = "Target Support Files/Pods-MVP/Pods-MVP.debug.xcconfig"; sourceTree = "<group>"; };
+		AC23ABC6245A82F9002D7764 /* Chat.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Chat.storyboard; sourceTree = "<group>"; };
+		AC23ABCA245A8C0C002D7764 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		AC48CE502459E6B300C8D3A6 /* Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		AC48CE512459E6B300C8D3A6 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		AC9135BD245CCC68006562AA /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
+		AC9135BF245CCD5C006562AA /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
 		AC9A766B24574D4600AB1906 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		ACEF808C245A149B009459FF /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		ACEF8090245A1A3A009459FF /* TestPostCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPostCategoryViewController.swift; sourceTree = "<group>"; };
@@ -158,6 +166,8 @@
 				AC48CE502459E6B300C8D3A6 /* Post.swift */,
 				AC48CE512459E6B300C8D3A6 /* User.swift */,
 				ACEF808C245A149B009459FF /* Category.swift */,
+				AC23ABCA245A8C0C002D7764 /* Message.swift */,
+				AC9135BF245CCD5C006562AA /* Chat.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -181,6 +191,7 @@
 				ACEF8090245A1A3A009459FF /* TestPostCategoryViewController.swift */,
 				D5762087245A677F00B5D417 /* TabBarViewController.swift */,
 				D576207B245A446300B5D417 /* Auth */,
+				AC9135BD245CCC68006562AA /* ChatViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -199,6 +210,7 @@
 				6D4A8A622458D07600F69923 /* AddPost.storyboard */,
 				6D4A8A602458D05500F69923 /* Home.storyboard */,
 				D5CF92CF24537B470059110B /* Main.storyboard */,
+				AC23ABC6245A82F9002D7764 /* Chat.storyboard */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -278,6 +290,7 @@
 				6D4A8A642458D07600F69923 /* AddPost.storyboard in Resources */,
 				6D4A8A6B2458D64300F69923 /* Profile.storyboard in Resources */,
 				D5CF92D124537B470059110B /* Main.storyboard in Resources */,
+				AC23ABC7245A82F9002D7764 /* Chat.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -333,6 +346,7 @@
 				D5762084245A456600B5D417 /* LoginViewController.swift in Sources */,
 				6D4A8A662458D32700F69923 /* PostListTableViewController.swift in Sources */,
 				6D4A8A682458D34200F69923 /* PostDetailViewController.swift in Sources */,
+				AC23ABCB245A8C0C002D7764 /* Message.swift in Sources */,
 				6D877E392459F4EE004C860D /* PhotoSelectorViewController.swift in Sources */,
 				D5CF92CA24537B470059110B /* AppDelegate.swift in Sources */,
 				D576207D245A448500B5D417 /* ViewController.swift in Sources */,
@@ -340,7 +354,9 @@
 				D5762080245A44D700B5D417 /* Utilities.swift in Sources */,
 				AC48CE522459E6B300C8D3A6 /* Post.swift in Sources */,
 				ACEF808D245A149B009459FF /* Category.swift in Sources */,
+				AC9135BE245CCC68006562AA /* ChatViewController.swift in Sources */,
 				D57620742458DE8F00B5D417 /* AddPostViewController.swift in Sources */,
+				AC9135C0245CCD5C006562AA /* Chat.swift in Sources */,
 				D5CF92CC24537B470059110B /* SceneDelegate.swift in Sources */,
 				D5762082245A44F500B5D417 /* SignUpViewController.swift in Sources */,
 				D5762088245A677F00B5D417 /* TabBarViewController.swift in Sources */,

--- a/MVP/MVP.xcodeproj/project.pbxproj
+++ b/MVP/MVP.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		AC48CE532459E6B300C8D3A6 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC48CE512459E6B300C8D3A6 /* User.swift */; };
 		AC9135BE245CCC68006562AA /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135BD245CCC68006562AA /* ChatViewController.swift */; };
 		AC9135C0245CCD5C006562AA /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135BF245CCD5C006562AA /* Chat.swift */; };
+		AC9135C2245E626F006562AA /* ChatListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9135C1245E626F006562AA /* ChatListTableViewController.swift */; };
 		AC9A766C24574D4600AB1906 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC9A766B24574D4600AB1906 /* GoogleService-Info.plist */; };
 		ACEF808D245A149B009459FF /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEF808C245A149B009459FF /* Category.swift */; };
 		ACEF8091245A1A3A009459FF /* TestPostCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEF8090245A1A3A009459FF /* TestPostCategoryViewController.swift */; };
@@ -51,6 +52,7 @@
 		AC48CE512459E6B300C8D3A6 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		AC9135BD245CCC68006562AA /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		AC9135BF245CCD5C006562AA /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
+		AC9135C1245E626F006562AA /* ChatListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListTableViewController.swift; sourceTree = "<group>"; };
 		AC9A766B24574D4600AB1906 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		ACEF808C245A149B009459FF /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		ACEF8090245A1A3A009459FF /* TestPostCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPostCategoryViewController.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 				D5762087245A677F00B5D417 /* TabBarViewController.swift */,
 				D576207B245A446300B5D417 /* Auth */,
 				AC9135BD245CCC68006562AA /* ChatViewController.swift */,
+				AC9135C1245E626F006562AA /* ChatListTableViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -352,6 +355,7 @@
 				D576207D245A448500B5D417 /* ViewController.swift in Sources */,
 				ACEF8091245A1A3A009459FF /* TestPostCategoryViewController.swift in Sources */,
 				D5762080245A44D700B5D417 /* Utilities.swift in Sources */,
+				AC9135C2245E626F006562AA /* ChatListTableViewController.swift in Sources */,
 				AC48CE522459E6B300C8D3A6 /* Post.swift in Sources */,
 				ACEF808D245A149B009459FF /* Category.swift in Sources */,
 				AC9135BE245CCC68006562AA /* ChatViewController.swift in Sources */,

--- a/MVP/MVP/Controllers/View Controllers/ChatListTableViewController.swift
+++ b/MVP/MVP/Controllers/View Controllers/ChatListTableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  ChatListTableViewController.swift
+//  MVP
+//
+//  Created by Theo Vora on 5/2/20.
+//  Copyright © 2020 coronacation. All rights reserved.
+//
+
+import UIKit
+import Firebase
+import FirebaseFirestore
+
+class ChatListTableViewController: UITableViewController {
+    
+    // MARK: - Properties
+    
+    var conversations = [String]() // an array of user names. for now.
+    
+    
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        loadConversations()
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        
+        return 1
+    }
+
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "chatCell", for: indexPath)
+
+        cell.textLabel?.text = "Tester 2"
+
+        return cell
+    }
+    
+    
+    // MARK: - Helper Functions
+    
+    func loadConversations() {
+//        conversations.append("Tester 2")
+        
+    }
+
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+    
+    
+
+    
+    // MARK: - Navigation
+
+    // toChatVC
+     
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // IIDOO
+        
+        
+        if segue.identifier == "toChatVC" {
+            guard let indexPath = tableView.indexPathForSelectedRow,
+                let destinationVC = segue.destination as? ChatViewController
+                else { return }
+            
+            let chat = conversations[indexPath.row]
+        }
+    }
+    
+}

--- a/MVP/MVP/Controllers/View Controllers/ChatListTableViewController.swift
+++ b/MVP/MVP/Controllers/View Controllers/ChatListTableViewController.swift
@@ -1,0 +1,91 @@
+//
+//  ChatListTableViewController.swift
+//  MVP
+//
+//  Created by Theo Vora on 5/2/20.
+//  Copyright © 2020 coronacation. All rights reserved.
+//
+
+import UIKit
+import Firebase
+import FirebaseFirestore
+
+class ChatListTableViewController: UITableViewController {
+    
+    // MARK: - Properties
+    
+    var conversations = [String]() // an array of user names. for now.
+    
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        loadConversations()
+    }
+    
+    // MARK: - Table view data source
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        
+        return 1
+    }
+    
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "chatCell", for: indexPath)
+        
+        cell.textLabel?.text = conversations[indexPath.row]
+        
+        return cell
+    }
+    
+    
+    // MARK: - Helper Functions
+    
+    func loadConversations() {
+        conversations.append("Tester 8")
+        
+    }
+    
+    
+    /*
+     // Override to support editing the table view.
+     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+     if editingStyle == .delete {
+     // Delete the row from the data source
+     tableView.deleteRows(at: [indexPath], with: .fade)
+     } else if editingStyle == .insert {
+     // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+     }
+     }
+     */
+    
+    
+    
+    
+    // MARK: - Navigation
+    
+    // toChatVC
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // IIDOO
+        
+        
+        if segue.identifier == "toChatVC" {
+            guard let indexPath = tableView.indexPathForSelectedRow,
+                //                let destinationVC = segue.destination as? ChatViewController
+                let _ = segue.destination as? ChatViewController
+                else { return }
+            
+            //            let chat = conversations[indexPath.row]
+            let _ = conversations[indexPath.row]
+        }
+    }
+    
+}

--- a/MVP/MVP/Controllers/View Controllers/ChatViewController.swift
+++ b/MVP/MVP/Controllers/View Controllers/ChatViewController.swift
@@ -35,8 +35,12 @@ class ChatViewController: MessagesViewController, MessagesDataSource, MessagesLa
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.user2UID = "iqsRveu1pVRy9AM0mwlszQYel5o2"
-        self.user2Name = "J-Dog"
+        //        self.user2Name = "J-Dog"
+//        self.user2UID = "iqsRveu1pVRy9AM0mwlszQYel5o2"
+        
+        self.user2Name = "Test2"
+        self.user2UID = "kIIEtZhu2HXFSjLxd5cck3vQTXV2"
+        
         //        self.title = user2Name ?? "Chat" // this overrides the tab bar item name
         
         messageInputBar.delegate = self

--- a/MVP/MVP/Controllers/View Controllers/ChatViewController.swift
+++ b/MVP/MVP/Controllers/View Controllers/ChatViewController.swift
@@ -1,0 +1,249 @@
+//
+//  ChatViewController.swift
+//  MVP
+//
+//  Created by Theo Vora on 5/1/20.
+//  Copyright © 2020 coronacation. All rights reserved.
+//
+
+import InputBarAccessoryView
+import MessageKit
+import Firebase
+import FirebaseFirestore
+import SDWebImage
+
+class ChatViewController: MessagesViewController, MessagesDataSource, MessagesLayoutDelegate, MessagesDisplayDelegate, MessageCellDelegate { //InputBarAccessoryViewDelegate
+    
+    // MARK: - Properties
+    
+    var currentUser = Auth.auth().currentUser!
+    var currentUserdisplayName = Auth.auth().currentUser!.displayName ?? Auth.auth().currentUser!.email ?? "hacker"
+    
+    
+    // USER2 - the user that currentUser is chatting with
+    var user2Name: String?
+    var user2ImgUrl: String?
+    var user2UID: String?
+    
+    private var docReference: DocumentReference?
+    
+    var messages: [Message] = []
+    
+    
+    // MARK: - Lifecycle Methods
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.user2UID = "iqsRveu1pVRy9AM0mwlszQYel5o2"
+        self.user2Name = "J-Dog"
+        //        self.title = user2Name ?? "Chat" // this overrides the tab bar item name
+        
+        messageInputBar.delegate = self
+        navigationItem.largeTitleDisplayMode = .never
+        maintainPositionOnKeyboardFrameChanged = true
+        messageInputBar.inputTextView.tintColor = .purple
+        messageInputBar.sendButton.setTitleColor(.systemBlue, for: .normal)
+        
+        messagesCollectionView.messagesDataSource = self
+        messagesCollectionView.messagesLayoutDelegate = self
+        messagesCollectionView.messagesDisplayDelegate = self
+        messagesCollectionView.messageCellDelegate = self
+        
+        loadChat()
+        
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        self.becomeFirstResponder()
+    }
+    
+    
+    // MARK: - Custom messages handlers
+    
+    func createNewChat() {
+        let users = [self.currentUser.uid, self.user2UID]
+        let data: [String: Any] = [
+            "users":users
+        ]
+        
+        let db = Firestore.firestore().collection("Chats")
+        db.addDocument(data: data) { (error) in
+            if let error = error {
+                print("Unable to create chat! \(error)")
+                return
+            } else {
+                self.loadChat()
+            }
+        }
+    }
+    
+    func loadChat() {
+        
+        //Fetch all the chats which has current user in it
+        let db = Firestore.firestore().collection("Chats")
+            .whereField("users", arrayContains: Auth.auth().currentUser?.uid ?? "Not Found User 1")
+        
+        
+        db.getDocuments { (chatQuerySnap, error) in
+            
+            if let error = error {
+                print("Error: \(error)")
+                return
+            } else {
+                
+                //Count the no. of documents returned
+                guard let queryCount = chatQuerySnap?.documents.count else {
+                    return
+                }
+                
+                if queryCount == 0 {
+                    //If documents count is zero that means there is no chat available and we need to create a new instance
+                    self.createNewChat()
+                }
+                else if queryCount >= 1 {
+                    //Chat(s) found for currentUser
+                    for doc in chatQuerySnap!.documents {
+                        
+                        let chat = Chat(dictionary: doc.data())
+                        //Get the chat which has user2 id
+                        if (chat?.users.contains(self.user2UID!))! {
+                            
+                            self.docReference = doc.reference
+                            //fetch it's thread collection
+                            doc.reference.collection("thread")
+                                .order(by: "created", descending: false)
+                                .addSnapshotListener(includeMetadataChanges: true, listener: { (threadQuery, error) in
+                                    if let error = error {
+                                        print("Error: \(error)")
+                                        return
+                                    } else {
+                                        self.messages.removeAll()
+                                        for message in threadQuery!.documents {
+                                            
+                                            let msg = Message(dictionary: message.data())
+                                            self.messages.append(msg!)
+                                            print("Data: \(msg?.content ?? "No message found")")
+                                        }
+                                        self.messagesCollectionView.reloadData()
+                                        self.messagesCollectionView.scrollToBottom(animated: true)
+                                    }
+                                })
+                            return
+                        } //end of if
+                    } //end of for
+                    self.createNewChat()
+                } else {
+                    print("Let's hope this error never prints!")
+                }
+            }
+        }
+    }
+    
+    
+    private func insertNewMessage(_ message: Message) {
+        
+        messages.append(message)
+        messagesCollectionView.reloadData()
+        
+        DispatchQueue.main.async {
+            self.messagesCollectionView.scrollToBottom(animated: true)
+        }
+    }
+    
+    private func save(_ message: Message) {
+        
+        let data: [String: Any] = [
+            "content": message.content,
+            "created": message.created,
+            "id": message.id,
+            "senderID": message.senderID,
+            "senderName": message.senderName
+        ]
+        
+        docReference?.collection("thread").addDocument(data: data, completion: { (error) in
+            
+            if let error = error {
+                print("Error Sending message: \(error)")
+                return
+            }
+            
+            self.messagesCollectionView.scrollToBottom()
+            
+        })
+    }
+    
+    
+    // MARK: - MessagesDataSource
+    func currentSender() -> SenderType {
+        
+        return Sender(senderId: Auth.auth().currentUser!.uid, displayName: currentUserdisplayName)
+        
+    }
+    
+    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
+        
+        return messages[indexPath.section]
+        
+    }
+    
+    func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+        
+        if messages.count == 0 {
+            print("No messages to display")
+            return 0
+        } else {
+            return messages.count
+        }
+    }
+    
+    
+    // MARK: - MessagesLayoutDelegate
+    
+    func avatarSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
+        return .zero
+    }
+    
+    // MARK: - MessagesDisplayDelegate
+    func backgroundColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        return isFromCurrentSender(message: message) ? .blue: .lightGray
+    }
+    
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {
+        
+        if message.sender.senderId == currentUser.uid {
+            SDWebImageManager.shared.loadImage(with: currentUser.photoURL, options: .highPriority, progress: nil) { (image, data, error, cacheType, isFinished, imageUrl) in
+                avatarView.image = image
+            }
+        } else {
+            SDWebImageManager.shared.loadImage(with: URL(string: user2ImgUrl!), options: .highPriority, progress: nil) { (image, data, error, cacheType, isFinished, imageUrl) in
+                avatarView.image = image
+            }
+        }
+    }
+    
+    func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
+        
+        let corner: MessageStyle.TailCorner = isFromCurrentSender(message: message) ? .bottomRight: .bottomLeft
+        return .bubbleTail(corner, .curved)
+        
+    }
+}
+
+// MARK: - InputBarAccessoryViewDelegate
+
+extension ChatViewController: InputBarAccessoryViewDelegate {
+    
+    func inputBar(_ inputBar: InputBarAccessoryView, didPressSendButtonWith text: String) {
+        
+        let message = Message(id: UUID().uuidString, content: text, created: Timestamp(), senderID: currentUser.uid, senderName: currentUserdisplayName)
+        
+        //messages.append(message)
+        insertNewMessage(message)
+        save(message)
+        
+        inputBar.inputTextView.text = ""
+        messagesCollectionView.reloadData()
+        messagesCollectionView.scrollToBottom(animated: true)
+    }
+}

--- a/MVP/MVP/Controllers/View Controllers/ChatViewController.swift
+++ b/MVP/MVP/Controllers/View Controllers/ChatViewController.swift
@@ -1,0 +1,247 @@
+//
+//  ChatViewController.swift
+//  MVP
+//
+//  Created by Theo Vora on 5/1/20.
+//  Copyright © 2020 coronacation. All rights reserved.
+//
+
+import InputBarAccessoryView
+import MessageKit
+import Firebase
+import FirebaseFirestore
+import SDWebImage
+
+class ChatViewController: MessagesViewController, MessagesDataSource, MessagesLayoutDelegate, MessagesDisplayDelegate, MessageCellDelegate { //InputBarAccessoryViewDelegate
+    
+    // MARK: - Properties
+    
+    var currentUser = CurrentUserController.shared.currentUser!
+    
+    
+    // USER2 - the user that currentUser is chatting with
+    var user2Name: String?
+    var user2ImgUrl: String?
+    var user2UID: String?
+    
+    private var docReference: DocumentReference?
+    
+    var messages: [Message] = []
+    
+    
+    // MARK: - Lifecycle Methods
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.user2Name = "Tester8"
+        self.user2UID = "7hf3hJeLPLXYk3D4I7IPEE8X9fv2"
+                
+        messageInputBar.delegate = self
+        navigationItem.largeTitleDisplayMode = .never
+        maintainPositionOnKeyboardFrameChanged = true
+        messageInputBar.inputTextView.tintColor = .purple
+        messageInputBar.sendButton.setTitleColor(.systemBlue, for: .normal)
+        
+        messagesCollectionView.messagesDataSource = self
+        messagesCollectionView.messagesLayoutDelegate = self
+        messagesCollectionView.messagesDisplayDelegate = self
+        messagesCollectionView.messageCellDelegate = self
+        
+        loadChat()
+        
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        self.becomeFirstResponder()
+    }
+    
+    
+    // MARK: - Custom messages handlers
+    
+    func createNewChat() {
+        let users = [self.currentUser.userUID, self.user2UID]
+        let data: [String: Any] = [
+            "users":users
+        ]
+        
+        let db = Firestore.firestore().collection("Chats")
+        db.addDocument(data: data) { (error) in
+            if let error = error {
+                print("Unable to create chat! \(error)")
+                return
+            } else {
+                self.loadChat()
+            }
+        }
+    }
+    
+    func loadChat() {
+        
+        //Fetch all the chats which has current user in it
+        let db = Firestore.firestore().collection("Chats")
+            .whereField("users", arrayContains: Auth.auth().currentUser?.uid ?? "Not Found User 1")
+        
+        
+        db.getDocuments { (chatQuerySnap, error) in
+            
+            if let error = error {
+                print("Error: \(error)")
+                return
+            } else {
+                
+                //Count the no. of documents returned
+                guard let queryCount = chatQuerySnap?.documents.count else {
+                    return
+                }
+                
+                if queryCount == 0 {
+                    //If documents count is zero that means there is no chat available and we need to create a new instance
+                    self.createNewChat()
+                }
+                else if queryCount >= 1 {
+                    //Chat(s) found for currentUser
+                    for doc in chatQuerySnap!.documents {
+                        
+                        let chat = Chat(dictionary: doc.data())
+                        //Get the chat which has user2 id
+                        if (chat?.users.contains(self.user2UID!))! {
+                            
+                            self.docReference = doc.reference
+                            //fetch it's thread collection
+                            doc.reference.collection("thread")
+                                .order(by: "created", descending: false)
+                                .addSnapshotListener(includeMetadataChanges: true, listener: { (threadQuery, error) in
+                                    if let error = error {
+                                        print("Error: \(error)")
+                                        return
+                                    } else {
+                                        self.messages.removeAll()
+                                        for message in threadQuery!.documents {
+                                            
+                                            let msg = Message(dictionary: message.data())
+                                            self.messages.append(msg!)
+                                            print("Data: \(msg?.content ?? "No message found")")
+                                        }
+                                        self.messagesCollectionView.reloadData()
+                                        self.messagesCollectionView.scrollToBottom(animated: true)
+                                    }
+                                })
+                            return
+                        } //end of if
+                    } //end of for
+                    self.createNewChat()
+                } else {
+                    print("Let's hope this error never prints!")
+                }
+            }
+        }
+    }
+    
+    
+    private func insertNewMessage(_ message: Message) {
+        
+        messages.append(message)
+        messagesCollectionView.reloadData()
+        
+        DispatchQueue.main.async {
+            self.messagesCollectionView.scrollToBottom(animated: true)
+        }
+    }
+    
+    private func save(_ message: Message) {
+        
+        let data: [String: Any] = [
+            "content": message.content,
+            "created": message.created,
+            "id": message.id,
+            "senderID": message.senderID,
+            "senderName": currentUser.fullName
+        ]
+        
+        docReference?.collection("thread").addDocument(data: data, completion: { (error) in
+            
+            if let error = error {
+                print("Error Sending message: \(error)")
+                return
+            }
+            
+            self.messagesCollectionView.scrollToBottom()
+            
+        })
+    }
+    
+    
+    // MARK: - MessagesDataSource
+    func currentSender() -> SenderType {
+        
+        return Sender(senderId: currentUser.userUID, displayName: currentUser.fullName)
+        
+    }
+    
+    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
+        
+        return messages[indexPath.section]
+        
+    }
+    
+    func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+        
+        if messages.count == 0 {
+            print("No messages to display")
+            return 0
+        } else {
+            return messages.count
+        }
+    }
+    
+    
+    // MARK: - MessagesLayoutDelegate
+    
+    func avatarSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
+        return .zero
+    }
+    
+    // MARK: - MessagesDisplayDelegate
+    func backgroundColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        return isFromCurrentSender(message: message) ? .blue: .lightGray
+    }
+    
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {
+        
+        if message.sender.senderId == currentUser.userUID {
+            SDWebImageManager.shared.loadImage(with: currentUser.photoURL, options: .highPriority, progress: nil) { (image, data, error, cacheType, isFinished, imageUrl) in
+                avatarView.image = image
+            }
+        } else {
+            SDWebImageManager.shared.loadImage(with: URL(string: user2ImgUrl!), options: .highPriority, progress: nil) { (image, data, error, cacheType, isFinished, imageUrl) in
+                avatarView.image = image
+            }
+        }
+    }
+    
+    func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
+        
+        let corner: MessageStyle.TailCorner = isFromCurrentSender(message: message) ? .bottomRight: .bottomLeft
+        return .bubbleTail(corner, .curved)
+        
+    }
+}
+
+// MARK: - InputBarAccessoryViewDelegate
+
+extension ChatViewController: InputBarAccessoryViewDelegate {
+    
+    func inputBar(_ inputBar: InputBarAccessoryView, didPressSendButtonWith text: String) {
+        
+        let message = Message(id: UUID().uuidString, content: text, created: Timestamp(), senderID: currentUser.userUID, senderName: currentUser.fullName)
+        
+        //messages.append(message)
+        insertNewMessage(message)
+        save(message)
+        
+        inputBar.inputTextView.text = ""
+        messagesCollectionView.reloadData()
+        messagesCollectionView.scrollToBottom(animated: true)
+    }
+}

--- a/MVP/MVP/Models/Chat.swift
+++ b/MVP/MVP/Models/Chat.swift
@@ -1,0 +1,25 @@
+//
+//  Chat.swift
+//  MVP
+//
+//  Created by Theo Vora on 5/1/20.
+//  Copyright © 2020 coronacation. All rights reserved.
+//
+
+import UIKit
+
+struct Chat {
+    var users: [String]
+    var dictionary: [String: Any] {
+        return ["users": users]
+    }
+}
+
+extension Chat {
+    
+    init?(dictionary: [String:Any]) {
+        guard let chatUsers = dictionary["users"] as? [String] else {return nil}
+        self.init(users: chatUsers)
+    }
+    
+}

--- a/MVP/MVP/Models/Message.swift
+++ b/MVP/MVP/Models/Message.swift
@@ -1,0 +1,70 @@
+//
+//  Message.swift
+//  MVP
+//
+//  Created by Theo Vora on 4/29/20.
+//  Copyright © 2020 coronacation. All rights reserved.
+//
+
+import Foundation
+import Firebase
+import MessageKit
+
+struct Message {
+    
+    var id: String
+    var content: String
+    var created: Timestamp
+    var senderID: String
+    var senderName: String
+    
+    var dictionary: [String: Any] {
+        
+        return [
+            "id": id,
+            "content": content,
+            "created": created,
+            "senderID": senderID,
+            "senderName":senderName]
+        
+    }
+}
+
+extension Message {
+    init?(dictionary: [String: Any]) {
+        
+        guard let id = dictionary["id"] as? String,
+            let content = dictionary["content"] as? String,
+            let created = dictionary["created"] as? Timestamp,
+            let senderID = dictionary["senderID"] as? String,
+            let senderName = dictionary["senderName"] as? String
+            else {return nil}
+        
+        self.init(id: id, content: content, created: created, senderID: senderID, senderName:senderName)
+        
+    }
+}
+
+extension Message: MessageType {
+    
+    var sender: SenderType {
+        return Sender(senderId: senderID, displayName: senderName)
+    }
+    
+    var messageId: String {
+        return id
+    }
+    
+    var sentDate: Date {
+        return created.dateValue()
+    }
+    
+    var kind: MessageKind {
+        return .text(content)
+    }
+}
+
+struct Sender: SenderType {
+    var senderId: String
+    var displayName: String
+}

--- a/MVP/MVP/Models/User.swift
+++ b/MVP/MVP/Models/User.swift
@@ -15,8 +15,14 @@ struct CurrentUser {
     var email: String
     let userUID: String
     
-    //will be adding profile photo
+    var fullName: String {
+        get {
+            return firstName + " " + lastName
+        }
+    }
     
+    //will be adding profile photo
+    var photoURL: URL = URL(string: "https://cdn4.iconfinder.com/data/icons/avatars-xmas-giveaway/128/batman_hero_avatar_comics-512.png")!
 }
 
 class User {

--- a/MVP/MVP/Views/Base.lproj/Main.storyboard
+++ b/MVP/MVP/Views/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cAI-pW-l2o">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,6 +20,7 @@
                         <segue destination="guz-K8-CiP" kind="relationship" relationship="viewControllers" id="QeR-x4-LF4"/>
                         <segue destination="8JS-Zp-ICn" kind="relationship" relationship="viewControllers" id="EvS-xK-18A"/>
                         <segue destination="J8b-dc-FaJ" kind="relationship" relationship="viewControllers" id="jFP-vL-1gf"/>
+                        <segue destination="PSo-L1-nbG" kind="relationship" relationship="viewControllers" id="FK7-SM-zA6"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DAN-jr-LFl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -55,6 +56,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="s2t-bt-hy7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4006" y="404"/>
+        </scene>
+        <!--Chat-->
+        <scene sceneID="wNP-OM-rUt">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Chat" id="PSo-L1-nbG" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="Rpa-jK-lCc"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xxi-Es-a7i" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4251" y="404"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="dQA-4S-VbL">

--- a/MVP/MVP/Views/Base.lproj/Main.storyboard
+++ b/MVP/MVP/Views/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cAI-pW-l2o">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,6 +20,7 @@
                         <segue destination="guz-K8-CiP" kind="relationship" relationship="viewControllers" id="QeR-x4-LF4"/>
                         <segue destination="8JS-Zp-ICn" kind="relationship" relationship="viewControllers" id="EvS-xK-18A"/>
                         <segue destination="J8b-dc-FaJ" kind="relationship" relationship="viewControllers" id="jFP-vL-1gf"/>
+                        <segue destination="PSo-L1-nbG" kind="relationship" relationship="viewControllers" id="FK7-SM-zA6"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DAN-jr-LFl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -56,10 +57,20 @@
             </objects>
             <point key="canvasLocation" x="4006" y="404"/>
         </scene>
+        <!--Chat-->
+        <scene sceneID="wNP-OM-rUt">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Chat" id="PSo-L1-nbG" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="Rpa-jK-lCc"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xxi-Es-a7i" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4251" y="404"/>
+        </scene>
         <!--View Controller-->
         <scene sceneID="dQA-4S-VbL">
             <objects>
-                <viewController id="z1I-jc-LE5" customClass="ViewController" customModule="login" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="z1I-jc-LE5" customClass="ViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PO6-up-eR8">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -111,7 +122,7 @@
         <!--Login View Controller-->
         <scene sceneID="pGt-Go-Aq7">
             <objects>
-                <viewController id="hqv-zN-8mW" customClass="LoginViewController" customModule="login" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="hqv-zN-8mW" customClass="LoginViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="KSb-Vg-Zkd">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -175,7 +186,7 @@
         <!--Sign Up View Controller-->
         <scene sceneID="EbW-Yf-eHe">
             <objects>
-                <viewController id="nUJ-vy-iQk" customClass="SignUpViewController" customModule="login" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="nUJ-vy-iQk" customClass="SignUpViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dd0-z4-PlZ">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/MVP/MVP/Views/Chat.storyboard
+++ b/MVP/MVP/Views/Chat.storyboard
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="7b1-EW-iOr">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Chat-->
+        <scene sceneID="dr7-PL-7ef">
+            <objects>
+                <tableViewController id="C1G-1s-3Vx" customClass="ChatListTableViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="X8W-TI-eaL">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="chatCell" textLabel="bRn-bg-4mA" style="IBUITableViewCellStyleDefault" id="7Lp-vR-wbn">
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7Lp-vR-wbn" id="K3A-ON-NcZ">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bRn-bg-4mA">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="47v-cc-bZS" kind="show" identifier="toChatVC" id="QNJ-ib-xDc"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="C1G-1s-3Vx" id="2ca-Ug-3wp"/>
+                            <outlet property="delegate" destination="C1G-1s-3Vx" id="gAU-SF-MBO"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Chat" id="8S2-e3-3KX">
+                        <barButtonItem key="backBarButtonItem" title="Back" id="re7-az-han"/>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1Hh-yb-9Qp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-726" y="49"/>
+        </scene>
+        <!--Chat-->
+        <scene sceneID="dpk-iL-JsC">
+            <objects>
+                <navigationController id="7b1-EW-iOr" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Chat" image="bubble.left" catalog="system" id="EXd-zJ-ByE" userLabel="Chat"/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="y5t-uW-qma">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="C1G-1s-3Vx" kind="relationship" relationship="rootViewController" id="m4Q-RC-yV2"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="slN-XI-F8z" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1642" y="49"/>
+        </scene>
+        <!--Chat View Controller-->
+        <scene sceneID="FTv-K7-GeJ">
+            <objects>
+                <viewController id="47v-cc-bZS" customClass="ChatViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="aMX-Js-4Gb">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="lGU-6j-oAd"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="NA4-KO-Hne"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sqL-aS-l1o" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="220" y="49"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="bubble.left" catalog="system" width="128" height="110"/>
+    </resources>
+</document>

--- a/MVP/MVP/Views/Chat.storyboard
+++ b/MVP/MVP/Views/Chat.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="47v-cc-bZS">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Chat View Controller-->
+        <scene sceneID="FTv-K7-GeJ">
+            <objects>
+                <viewController id="47v-cc-bZS" customClass="ChatViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="aMX-Js-4Gb">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="lGU-6j-oAd"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sqL-aS-l1o" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="63" y="52"/>
+        </scene>
+    </scenes>
+</document>

--- a/MVP/MVP/Views/Chat.storyboard
+++ b/MVP/MVP/Views/Chat.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="47v-cc-bZS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="7b1-EW-iOr">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -7,6 +7,67 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--Chat-->
+        <scene sceneID="dr7-PL-7ef">
+            <objects>
+                <tableViewController id="C1G-1s-3Vx" customClass="ChatListTableViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="X8W-TI-eaL">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="chatCell" textLabel="bRn-bg-4mA" style="IBUITableViewCellStyleDefault" id="7Lp-vR-wbn">
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7Lp-vR-wbn" id="K3A-ON-NcZ">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bRn-bg-4mA">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="47v-cc-bZS" kind="show" identifier="toChatVC" id="QNJ-ib-xDc"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="C1G-1s-3Vx" id="2ca-Ug-3wp"/>
+                            <outlet property="delegate" destination="C1G-1s-3Vx" id="gAU-SF-MBO"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Chat" id="8S2-e3-3KX">
+                        <barButtonItem key="backBarButtonItem" title="Back" id="re7-az-han"/>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1Hh-yb-9Qp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-726" y="49"/>
+        </scene>
+        <!--Chat-->
+        <scene sceneID="dpk-iL-JsC">
+            <objects>
+                <navigationController id="7b1-EW-iOr" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Chat" image="bubble.left" catalog="system" id="EXd-zJ-ByE" userLabel="Chat"/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="y5t-uW-qma">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="C1G-1s-3Vx" kind="relationship" relationship="rootViewController" id="m4Q-RC-yV2"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="slN-XI-F8z" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1642" y="49"/>
+        </scene>
         <!--Chat View Controller-->
         <scene sceneID="FTv-K7-GeJ">
             <objects>
@@ -17,10 +78,14 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="lGU-6j-oAd"/>
                     </view>
+                    <navigationItem key="navigationItem" id="NA4-KO-Hne"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sqL-aS-l1o" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="63" y="52"/>
+            <point key="canvasLocation" x="220" y="49"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="bubble.left" catalog="system" width="128" height="110"/>
+    </resources>
 </document>

--- a/MVP/Podfile
+++ b/MVP/Podfile
@@ -10,6 +10,7 @@ target 'MVP' do
   pod 'Firebase/Auth'
   pod 'Firebase/Storage'
   pod 'Firebase/Firestore'
-  
+  pod 'MessageKit'
+  pod 'SDWebImage'
 
 end

--- a/MVP/Podfile.lock
+++ b/MVP/Podfile.lock
@@ -247,18 +247,28 @@ PODS:
     - nanopb (~> 0.3)
   - gRPC-Core/Interface (1.21.0)
   - GTMSessionFetcher/Core (1.3.1)
+  - InputBarAccessoryView (4.3.2):
+    - InputBarAccessoryView/Core (= 4.3.2)
+  - InputBarAccessoryView/Core (4.3.2)
   - leveldb-library (1.22)
+  - MessageKit (3.1.0):
+    - InputBarAccessoryView (~> 4.3.0)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
   - nanopb/decode (0.3.9011)
   - nanopb/encode (0.3.9011)
   - PromisesObjC (1.2.8)
+  - SDWebImage (5.7.3):
+    - SDWebImage/Core (= 5.7.3)
+  - SDWebImage/Core (5.7.3)
 
 DEPENDENCIES:
   - Firebase/Auth
   - Firebase/Firestore
   - Firebase/Storage
+  - MessageKit
+  - SDWebImage
 
 SPEC REPOS:
   trunk:
@@ -278,9 +288,12 @@ SPEC REPOS:
     - "gRPC-C++"
     - gRPC-Core
     - GTMSessionFetcher
+    - InputBarAccessoryView
     - leveldb-library
+    - MessageKit
     - nanopb
     - PromisesObjC
+    - SDWebImage
 
 SPEC CHECKSUMS:
   abseil: 18063d773f5366ff8736a050fe035a28f635fd27
@@ -299,10 +312,13 @@ SPEC CHECKSUMS:
   "gRPC-C++": 9dfe7b44821e7b3e44aacad2af29d2c21f7cde83
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
+  InputBarAccessoryView: 7985d418040a05fe894bd4b8328dd43ab35517c3
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
+  MessageKit: 3beb578737a5aa2bba25cc27c7b6d6faa09af5a7
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
+  SDWebImage: 97351f6582ceca541ea294ba66a1fcb342a331c2
 
-PODFILE CHECKSUM: 963d2e421c43a03ed3457dcfafb76e07b851f25f
+PODFILE CHECKSUM: f184d14c9d929d46e703a58c9135b4ea25a56091
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
"Skeleton" meaning it has a hard coded TableList that shows only 1 user. The Segue works nicely to the Chat Detail View. But again, the Chat Detail View is hardcoded to 1 user. Those chat message pull directly from Firestore.

In more definitive news, our 4th tab, Chat, has finally joined the party.

@davejacobsen I had to tweak the CurrentUser model a bit to make it work with Chat just to get it building. You can see the changes I made in User.swift. Feel free to alter and change values to your liking.

Everyone, you'll have to `pod install` after you `git pull origin develop` (make sure you're checked out to your local develop branch).