### PR TITLE
Rev to v0.0.3

### DIFF
--- a/MVP/MVP.xcodeproj/project.pbxproj
+++ b/MVP/MVP.xcodeproj/project.pbxproj
@@ -693,7 +693,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.coronacation.weshare;
 				PRODUCT_NAME = WeShare;
 				SWIFT_VERSION = 5.0;
@@ -716,7 +716,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.coronacation.weshare;
 				PRODUCT_NAME = WeShare;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
The datatype of Post Timestamp has changed from String to Firestore.Timestamp. Therefore, all previous versions are incompatible, and we must rev our version.